### PR TITLE
Update context, add credentials.go, and update middleware.

### DIFF
--- a/auth/context.go
+++ b/auth/context.go
@@ -7,7 +7,8 @@ import (
 	"github.com/tesseral-labs/tesseral-sdk-go"
 )
 
-var errNotAnAccessToken = fmt.Errorf("not an access token")
+// ErrNotAnAccessToken is returned from AccessTokenClaims if a request does not use an access token.
+var ErrNotAnAccessToken = fmt.Errorf("not an access token")
 
 type ctxKey struct{}
 
@@ -55,7 +56,7 @@ func mustAuthContext(ctx context.Context, name string) *ctxValue {
 // request.
 //
 // For accessToken-based authentication, this will be "access_token". For
-// apiKey-based authentication, this will be "api_key".
+// API Key-based authentication, this will be "api_key".
 func CredentialsType(ctx context.Context) string {
 	v := mustAuthContext(ctx, "CredentialsType")
 
@@ -90,8 +91,6 @@ func OrganizationID(ctx context.Context) string {
 // Future versions of this package may add support for other kinds of
 // authentication than access tokens, in which case AccessTokenClaims may return
 // an error.
-//
-// Panics if the provided ctx isn't downstream of [RequireAuth].
 func AccessTokenClaims(ctx context.Context) (*tesseral.AccessTokenClaims, error) {
 	v := mustAuthContext(ctx, "AccessTokenClaims")
 
@@ -99,7 +98,7 @@ func AccessTokenClaims(ctx context.Context) (*tesseral.AccessTokenClaims, error)
 		return v.accessTokenDetails.claims, nil
 	}
 
-	return nil, errNotAnAccessToken
+	return nil, ErrNotAnAccessToken
 }
 
 // Credentials returns the request's original credentials.

--- a/auth/context.go
+++ b/auth/context.go
@@ -91,14 +91,19 @@ func OrganizationID(ctx context.Context) string {
 // Future versions of this package may add support for other kinds of
 // authentication than access tokens, in which case AccessTokenClaims may return
 // an error.
+//
+// Panics if the provided ctx isn't downstream of [RequireAuth].
 func AccessTokenClaims(ctx context.Context) (*tesseral.AccessTokenClaims, error) {
 	v := mustAuthContext(ctx, "AccessTokenClaims")
 
 	if v.accessTokenDetails != nil {
 		return v.accessTokenDetails.claims, nil
 	}
+	if v.apiKeyDetails != nil {
+		return nil, ErrNotAnAccessToken
+	}
 
-	return nil, ErrNotAnAccessToken
+	panic("unreachable")
 }
 
 // Credentials returns the request's original credentials.

--- a/auth/context.go
+++ b/auth/context.go
@@ -57,12 +57,12 @@ func mustAuthContext(ctx context.Context, name string) *ctxValue {
 // For accessToken-based authentication, this will be "access_token". For
 // apiKey-based authentication, this will be "api_key".
 func CredentialsType(ctx context.Context) string {
-	authCtx := mustAuthContext(ctx, "CredentialsType")
+	v := mustAuthContext(ctx, "CredentialsType")
 
-	if authCtx.apiKeyDetails != nil {
+	if v.apiKeyDetails != nil {
 		return "api_key"
 	}
-	if authCtx.accessTokenDetails != nil {
+	if v.accessTokenDetails != nil {
 		return "access_token"
 	}
 	panic("unreachable")
@@ -72,13 +72,13 @@ func CredentialsType(ctx context.Context) string {
 //
 // Panics if the provided ctx isn't downstream of [RequireAuth].
 func OrganizationID(ctx context.Context) string {
-	authCtx := mustAuthContext(ctx, "OrganizationID")
+	v := mustAuthContext(ctx, "OrganizationID")
 
-	if authCtx.apiKeyDetails != nil {
-		return *authCtx.apiKeyDetails.authenticateAPIKeyResponse.OrganizationID
+	if v.apiKeyDetails != nil {
+		return *v.apiKeyDetails.authenticateAPIKeyResponse.OrganizationID
 	}
-	if authCtx.accessTokenDetails != nil {
-		return authCtx.accessTokenDetails.claims.Organization.ID
+	if v.accessTokenDetails != nil {
+		return v.accessTokenDetails.claims.Organization.ID
 	}
 
 	panic("unreachable")
@@ -93,10 +93,10 @@ func OrganizationID(ctx context.Context) string {
 //
 // Panics if the provided ctx isn't downstream of [RequireAuth].
 func AccessTokenClaims(ctx context.Context) (*tesseral.AccessTokenClaims, error) {
-	authCtx := mustAuthContext(ctx, "AccessTokenClaims")
+	v := mustAuthContext(ctx, "AccessTokenClaims")
 
-	if authCtx.accessTokenDetails != nil {
-		return authCtx.accessTokenDetails.claims, nil
+	if v.accessTokenDetails != nil {
+		return v.accessTokenDetails.claims, nil
 	}
 
 	return nil, errNotAnAccessToken
@@ -106,12 +106,12 @@ func AccessTokenClaims(ctx context.Context) (*tesseral.AccessTokenClaims, error)
 //
 // Panics if the provided ctx isn't downstream of [RequireAuth].
 func Credentials(ctx context.Context) string {
-	authCtx := mustAuthContext(ctx, "Credentials")
-	if authCtx.apiKeyDetails != nil {
-		return authCtx.apiKeyDetails.apiKeySecretToken
+	v := mustAuthContext(ctx, "Credentials")
+	if v.apiKeyDetails != nil {
+		return v.apiKeyDetails.apiKeySecretToken
 	}
-	if authCtx.accessTokenDetails != nil {
-		return authCtx.accessTokenDetails.accessToken
+	if v.accessTokenDetails != nil {
+		return v.accessTokenDetails.accessToken
 	}
 
 	panic("unreachable")

--- a/auth/context.go
+++ b/auth/context.go
@@ -55,7 +55,7 @@ func mustAuthContext(ctx context.Context, name string) *ctxValue {
 // CredentialsType returns the type of credentials used to authenticate the
 // request.
 //
-// For accessToken-based authentication, this will be "access_token". For
+// For access token-based authentication, this will be "access_token". For
 // API Key-based authentication, this will be "api_key".
 func CredentialsType(ctx context.Context) string {
 	v := mustAuthContext(ctx, "CredentialsType")

--- a/auth/context_test.go
+++ b/auth/context_test.go
@@ -8,27 +8,70 @@ import (
 	"github.com/tesseral-labs/tesseral-sdk-go"
 )
 
-func TestOrganizationID(t *testing.T) {
-	ctx := newAuthContext(context.Background(), "", &tesseral.AccessTokenClaims{Organization: &tesseral.AccessTokenOrganization{ID: "foo"}})
+func TestOrganizationID_accesstoken(t *testing.T) {
+	ctx := newAccessTokenAuthContext(context.Background(), "", &tesseral.AccessTokenClaims{Organization: &tesseral.AccessTokenOrganization{ID: "foo"}})
 	assert.Equal(t, "foo", OrganizationID(ctx))
 }
 
-func TestCredentials(t *testing.T) {
-	ctx := newAuthContext(context.Background(), "foo", nil)
+func TestCredentials_accesstoken(t *testing.T) {
+	ctx := newAccessTokenAuthContext(context.Background(), "foo", nil)
 	assert.Equal(t, "foo", Credentials(ctx))
 }
 
-func TestAccessTokenClaims(t *testing.T) {
+func TestAccessTokenClaims_accesstoken(t *testing.T) {
 	want := &tesseral.AccessTokenClaims{Sub: "foo"}
-	ctx := newAuthContext(context.Background(), "", want)
+	ctx := newAccessTokenAuthContext(context.Background(), "", want)
 	got, err := AccessTokenClaims(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
 
-func TestHasPermission(t *testing.T) {
-	ctx := newAuthContext(context.Background(), "", &tesseral.AccessTokenClaims{Actions: []string{"a.b.c", "d.e.f"}})
+func TestHasPermission_accesstoken(t *testing.T) {
+	ctx := newAccessTokenAuthContext(context.Background(), "", &tesseral.AccessTokenClaims{Actions: []string{"a.b.c", "d.e.f"}})
 	assert.True(t, HasPermission(ctx, "a.b.c"))
 	assert.True(t, HasPermission(ctx, "d.e.f"))
 	assert.False(t, HasPermission(ctx, "x.y.z"))
+}
+
+func TestCredentialsType_accesstoken(t *testing.T) {
+	ctx := newAccessTokenAuthContext(context.Background(), "", nil)
+	assert.Equal(t, "access_token", CredentialsType(ctx))
+}
+
+func TestOrganizationID_apikey(t *testing.T) {
+	ctx := newAPIKeyAuthContext(context.Background(), "foo", &tesseral.AuthenticateAPIKeyResponse{
+		APIKeyID:       tesseral.String("foo"),
+		OrganizationID: tesseral.String("foo"),
+		Actions:        []string{"a.b.c", "d.e.f"},
+	})
+	assert.Equal(t, "foo", OrganizationID(ctx))
+}
+
+func TestCredentials_apikey(t *testing.T) {
+	ctx := newAPIKeyAuthContext(context.Background(), "foo", &tesseral.AuthenticateAPIKeyResponse{
+		APIKeyID:       tesseral.String("foo"),
+		OrganizationID: tesseral.String("foo"),
+		Actions:        []string{"a.b.c", "d.e.f"},
+	})
+	assert.Equal(t, "foo", Credentials(ctx))
+}
+
+func TestHasPermission_apikey(t *testing.T) {
+	ctx := newAPIKeyAuthContext(context.Background(), "foo", &tesseral.AuthenticateAPIKeyResponse{
+		APIKeyID:       tesseral.String("foo"),
+		OrganizationID: tesseral.String("foo"),
+		Actions:        []string{"a.b.c", "d.e.f"},
+	})
+	assert.True(t, HasPermission(ctx, "a.b.c"))
+	assert.True(t, HasPermission(ctx, "d.e.f"))
+	assert.False(t, HasPermission(ctx, "x.y.z"))
+}
+
+func TestCredentialsType_apikey(t *testing.T) {
+	ctx := newAPIKeyAuthContext(context.Background(), "foo", &tesseral.AuthenticateAPIKeyResponse{
+		APIKeyID:       tesseral.String("foo"),
+		OrganizationID: tesseral.String("foo"),
+		Actions:        []string{"a.b.c", "d.e.f"},
+	})
+	assert.Equal(t, "api_key", CredentialsType(ctx))
 }

--- a/auth/credentials.go
+++ b/auth/credentials.go
@@ -10,11 +10,11 @@ var (
 )
 
 // IsJWTFormat checks whether the string matches the structure of a JWT.
-func IsJWTFormat(value string) bool {
+func isJWTFormat(value string) bool {
 	return jwtRegex.MatchString(value)
 }
 
 // IsAPIKeyFormat checks whether the string is a valid API key format.
-func IsAPIKeyFormat(value string) bool {
+func isAPIKeyFormat(value string) bool {
 	return apiKeyRegex.MatchString(value)
 }

--- a/auth/credentials.go
+++ b/auth/credentials.go
@@ -9,12 +9,10 @@ var (
 	apiKeyRegex = regexp.MustCompile(`^[a-z0-9_]+$`)
 )
 
-// IsJWTFormat checks whether the string matches the structure of a JWT.
 func isJWTFormat(value string) bool {
 	return jwtRegex.MatchString(value)
 }
 
-// IsAPIKeyFormat checks whether the string is a valid API key format.
 func isAPIKeyFormat(value string) bool {
 	return apiKeyRegex.MatchString(value)
 }

--- a/auth/credentials.go
+++ b/auth/credentials.go
@@ -1,0 +1,20 @@
+package auth
+
+import (
+	"regexp"
+)
+
+var (
+	jwtRegex    = regexp.MustCompile(`^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$`)
+	apiKeyRegex = regexp.MustCompile(`^[a-z0-9_]+$`)
+)
+
+// IsJWTFormat checks whether the string matches the structure of a JWT.
+func IsJWTFormat(value string) bool {
+	return jwtRegex.MatchString(value)
+}
+
+// IsAPIKeyFormat checks whether the string is a valid API key format.
+func IsAPIKeyFormat(value string) bool {
+	return apiKeyRegex.MatchString(value)
+}

--- a/auth/credentials_test.go
+++ b/auth/credentials_test.go
@@ -42,7 +42,7 @@ func TestIsJWTFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsJWTFormat(tt.input)
+			result := isJWTFormat(tt.input)
 			if result != tt.expected {
 				t.Errorf("IsJWTFormat(%q) = %v; want %v", tt.input, result, tt.expected)
 			}
@@ -85,7 +85,7 @@ func TestIsAPIKeyFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsAPIKeyFormat(tt.input)
+			result := isAPIKeyFormat(tt.input)
 			if result != tt.expected {
 				t.Errorf("IsAPIKeyFormat(%q) = %v; want %v", tt.input, result, tt.expected)
 			}

--- a/auth/credentials_test.go
+++ b/auth/credentials_test.go
@@ -1,0 +1,94 @@
+package auth
+
+import (
+	"testing"
+)
+
+func TestIsJWTFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name: "valid JWT format",
+			input: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
+				".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6" +
+				"IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ" +
+				".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+			expected: true,
+		},
+		{
+			name:     "missing a part",
+			input:    "header.payload",
+			expected: false,
+		},
+		{
+			name:     "invalid characters",
+			input:    "header.payload.with=illegal&chars",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "extra segments",
+			input:    "a.b.c.d",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsJWTFormat(tt.input)
+			if result != tt.expected {
+				t.Errorf("IsJWTFormat(%q) = %v; want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsAPIKeyFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "valid API key format",
+			input:    "abc123_underscore",
+			expected: true,
+		},
+		{
+			name:     "uppercase letters",
+			input:    "ABC123",
+			expected: false,
+		},
+		{
+			name:     "invalid characters",
+			input:    "key-with-dash",
+			expected: false,
+		},
+		{
+			name:     "spaces",
+			input:    "key with space",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsAPIKeyFormat(tt.input)
+			if result != tt.expected {
+				t.Errorf("IsAPIKeyFormat(%q) = %v; want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -66,12 +66,17 @@ func RequireAuth(h http.Handler, opts ...Option) http.Handler {
 		panic("RequireAuth: tesseral client is required when API keys are enabled")
 	}
 
-	authn := accesstoken.NewAuthenticator(
-		WithPublishableKey(cfg.PublishableKey),
-		WithConfigAPIHostname(cfg.ConfigAPIHostname),
-		WithHTTPClient(cfg.HttpClient),
-		WithJWKSRefreshInterval(cfg.JwksRefreshInterval),
-	)
+	authnOpts := []accesstoken.Option{
+		accesstoken.WithPublishableKey(cfg.PublishableKey),
+		accesstoken.WithConfigAPIHostname(cfg.ConfigAPIHostname),
+		accesstoken.WithJWKSRefreshInterval(cfg.JwksRefreshInterval),
+	}
+
+	if cfg.HttpClient != nil {
+		authnOpts = append(authnOpts, accesstoken.WithHTTPClient(cfg.HttpClient))
+	}
+
+	authn := accesstoken.NewAuthenticator(authnOpts...)
 
 	tesseralClient := cfg.TesseralClient
 	if tesseralClient == nil {

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -68,12 +68,18 @@ func RequireAuth(h http.Handler, opts ...Option) http.Handler {
 
 	authnOpts := []accesstoken.Option{
 		accesstoken.WithPublishableKey(cfg.PublishableKey),
-		accesstoken.WithConfigAPIHostname(cfg.ConfigAPIHostname),
-		accesstoken.WithJWKSRefreshInterval(cfg.JwksRefreshInterval),
+	}
+
+	if cfg.ConfigAPIHostname != "" {
+		authnOpts = append(authnOpts, accesstoken.WithConfigAPIHostname(cfg.ConfigAPIHostname))
 	}
 
 	if cfg.HttpClient != nil {
 		authnOpts = append(authnOpts, accesstoken.WithHTTPClient(cfg.HttpClient))
+	}
+
+	if cfg.JwksRefreshInterval != 0 {
+		authnOpts = append(authnOpts, accesstoken.WithJWKSRefreshInterval(cfg.JwksRefreshInterval))
 	}
 
 	authn := accesstoken.NewAuthenticator(authnOpts...)

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -145,12 +145,9 @@ func RequireAuth(h http.Handler, opts ...Option) http.Handler {
 
 		credential := extractCredential(projectID, r)
 
-		fmt.Println("Credential:", credential)
-
 		if IsJWTFormat(credential) {
 			accessTokenClaims, err := authn.AuthenticateAccessToken(ctx, credential)
 			if err != nil {
-				fmt.Printf("RequireAuth: error authenticating access token: %w", err)
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -3,13 +3,24 @@ package auth
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
+	"time"
 
+	"github.com/tesseral-labs/tesseral-sdk-go"
 	"github.com/tesseral-labs/tesseral-sdk-go/accesstoken"
+	"github.com/tesseral-labs/tesseral-sdk-go/client"
 )
 
 // Option is an option for [RequireAuth].
-type Option = accesstoken.Option
+type Option struct {
+	PublishableKey      string
+	ConfigAPIHostname   string
+	HttpClient          *http.Client
+	JwksRefreshInterval time.Duration
+	APIKeysEnabled      *bool
+	TesseralClient      *client.Client
+}
 
 // WithPublishableKey sets the publishable key for [RequireAuth]. This is
 // always required.
@@ -42,8 +53,22 @@ var WithJWKSRefreshInterval = accesstoken.WithJWKSRefreshInterval
 //
 // If a request is authentic, h will be called with a request whose context
 // works with [OrganizationID], [AccessTokenClaims], and [Credentials].
-func RequireAuth(h http.Handler, opts ...Option) http.Handler {
-	authn := accesstoken.NewAuthenticator(opts...)
+func RequireAuth(h http.Handler, opts Option) http.Handler {
+	if opts.APIKeysEnabled != nil && *opts.APIKeysEnabled && opts.TesseralClient == nil && os.Getenv("TESSERAL_BACKEND_API_KEY") == "" {
+		panic("RequireAuth: tesseral client is required when API keys are enabled")
+	}
+
+	authn := accesstoken.NewAuthenticator(
+		WithConfigAPIHostname(opts.ConfigAPIHostname),
+		WithPublishableKey(opts.PublishableKey),
+		WithHTTPClient(opts.HttpClient),
+		WithJWKSRefreshInterval(opts.JwksRefreshInterval),
+	)
+
+	tesseralClient := opts.TesseralClient
+	if tesseralClient == nil {
+		tesseralClient = client.NewClient()
+	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -53,19 +78,35 @@ func RequireAuth(h http.Handler, opts ...Option) http.Handler {
 			panic(fmt.Errorf("RequireAuth: error fetching publishable key configuration: %w", err))
 		}
 
-		accessToken := extractAccessToken(projectID, r)
-		accessTokenClaims, err := authn.AuthenticateAccessToken(ctx, accessToken)
-		if err != nil {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
+		credential := extractCredential(projectID, r)
 
-		ctx = newAuthContext(ctx, accessToken, accessTokenClaims)
-		h.ServeHTTP(w, r.WithContext(ctx))
+		if IsJWTFormat(credential) {
+			accessTokenClaims, err := authn.AuthenticateAccessToken(ctx, credential)
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
+			ctx = newAccessTokenAuthContext(ctx, credential, accessTokenClaims)
+			h.ServeHTTP(w, r.WithContext(ctx))
+		} else if opts.APIKeysEnabled != nil && *opts.APIKeysEnabled && IsAPIKeyFormat(credential) {
+			apiKeyDetails, err := tesseralClient.APIKeys.AuthenticateAPIKey(ctx, &tesseral.AuthenticateAPIKeyRequest{
+				SecretToken: &credential,
+			})
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
+			ctx = newAPIKeyAuthContext(ctx, credential, apiKeyDetails)
+			h.ServeHTTP(w, r.WithContext(ctx))
+		} else {
+			w.WriteHeader(http.StatusUnauthorized)
+		}
 	})
 }
 
-func extractAccessToken(projectID string, r *http.Request) string {
+func extractCredential(projectID string, r *http.Request) string {
 	authorization := r.Header.Get("Authorization")
 	if strings.HasPrefix(authorization, "Bearer ") {
 		return strings.TrimPrefix(authorization, "Bearer ")

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -150,6 +150,7 @@ func RequireAuth(h http.Handler, opts ...Option) http.Handler {
 		if IsJWTFormat(credential) {
 			accessTokenClaims, err := authn.AuthenticateAccessToken(ctx, credential)
 			if err != nil {
+				fmt.Printf("RequireAuth: error authenticating access token: %w", err)
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -26,25 +26,41 @@ type Option func(*option)
 
 // WithPublishableKey sets the publishable key for [RequireAuth]. This is
 // always required.
-var WithPublishableKey = accesstoken.WithPublishableKey
+func WithPublishableKey(publishableKey string) Option {
+	return func(o *option) {
+		o.PublishableKey = publishableKey
+	}
+}
 
 // WithConfigAPIHostname sets the config API hostname for [RequireAuth].
 //
 // You can typically ignore this option. It is useful for those who self-host
 // Tesseral. The default is to use "config.tesseral.com".
-var WithConfigAPIHostname = accesstoken.WithConfigAPIHostname
+func WithConfigAPIHostname(hostname string) Option {
+	return func(o *option) {
+		o.ConfigAPIHostname = hostname
+	}
+}
 
 // WithHTTPClient sets the HTTP client used internally by [RequireAuth].
 //
 // The default is to use [http.DefaultClient].
-var WithHTTPClient = accesstoken.WithHTTPClient
+func WithHTTPClient(client *http.Client) Option {
+	return func(o *option) {
+		o.HttpClient = client
+	}
+}
 
 // WithJWKSRefreshInterval sets the JWKS refresh interval for [RequireAuth].
 //
 // [RequireAuth] keeps a cache of public keys used to sign access tokens. This
 // option controls how often that cache is updated. The default is to refresh
 // JWKS every 60 minutes.
-var WithJWKSRefreshInterval = accesstoken.WithJWKSRefreshInterval
+func WithJWKSRefreshInterval(interval time.Duration) Option {
+	return func(o *option) {
+		o.JwksRefreshInterval = interval
+	}
+}
 
 // RequireAuth blocks all request to h unless they are authenticated.
 //

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -26,12 +26,15 @@ type Option func(*options)
 
 // WithAPIKeysEnabled sets whether API keys are enabled for [RequireAuth].
 // This is optional. If not set, API keys are disabled.
+//
 // If set to true, the [RequireAuth] middleware will authenticate requests
 // using API keys. If set to false, the middleware will only authenticate
 // requests using access tokens.
+//
 // If API keys are enabled, you must provide a [TesseralClient] to
 // [RequireAuth] or have the `TESSERAL_BACKEND_API_KEY` environment variable
 // set.
+//
 // The middleware will use the default [client.NewClient] if one is not
 // provided.
 func WithAPIKeysEnabled(enabled bool) Option {
@@ -43,9 +46,11 @@ func WithAPIKeysEnabled(enabled bool) Option {
 // WithTesseralClient sets the Tesseral client for [RequireAuth].
 // This is optional. If not set, the middleware will use the default
 // [client.NewClient].
+//
 // If API keys are enabled, you must provide a [TesseralClient] to
 // [RequireAuth] or have the `TESSERAL_BACKEND_API_KEY` environment variable
 // set.
+//
 // The middleware will use the default [client.NewClient] if one is not
 // provided.
 func WithTesseralClient(client *client.Client) Option {
@@ -145,7 +150,7 @@ func RequireAuth(h http.Handler, opts ...Option) http.Handler {
 
 		credential := extractCredential(projectID, r)
 
-		if IsJWTFormat(credential) {
+		if isJWTFormat(credential) {
 			accessTokenClaims, err := authn.AuthenticateAccessToken(ctx, credential)
 			if err != nil {
 				w.WriteHeader(http.StatusUnauthorized)
@@ -154,7 +159,7 @@ func RequireAuth(h http.Handler, opts ...Option) http.Handler {
 
 			ctx = newAccessTokenAuthContext(ctx, credential, accessTokenClaims)
 			h.ServeHTTP(w, r.WithContext(ctx))
-		} else if cfg.apiKeysEnabled && IsAPIKeyFormat(credential) {
+		} else if cfg.apiKeysEnabled && isAPIKeyFormat(credential) {
 			apiKeyDetails, err := tesseralClient.APIKeys.AuthenticateAPIKey(ctx, &tesseral.AuthenticateAPIKeyRequest{
 				SecretToken: &credential,
 			})

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -12,7 +12,6 @@ import (
 	"github.com/tesseral-labs/tesseral-sdk-go/client"
 )
 
-// Option is an option for [RequireAuth].
 type options struct {
 	publishableKey      string
 	configAPIHostname   string
@@ -22,6 +21,7 @@ type options struct {
 	tesseralClient      *client.Client
 }
 
+// Option is an option for [RequireAuth].
 type Option func(*options)
 
 // WithAPIKeysEnabled sets whether API keys are enabled for [RequireAuth].

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -49,7 +49,7 @@ func TestExtractAccessToken(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractAccessToken(tt.projectID, tt.req)
+			got := extractCredential(tt.projectID, tt.req)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/core/request_option.go
+++ b/core/request_option.go
@@ -56,8 +56,8 @@ func (r *RequestOptions) cloneHeader() http.Header {
 	headers := r.HTTPHeader.Clone()
 	headers.Set("X-Fern-Language", "Go")
 	headers.Set("X-Fern-SDK-Name", "github.com/tesseral-labs/tesseral-sdk-go")
-	headers.Set("X-Fern-SDK-Version", "v0.0.6")
-	headers.Set("User-Agent", "github.com/tesseral-labs/tesseral-sdk-go/0.0.6")
+	headers.Set("X-Fern-SDK-Version", "v0.0.7")
+	headers.Set("User-Agent", "github.com/tesseral-labs/tesseral-sdk-go/0.0.7")
 	return headers
 }
 


### PR DESCRIPTION
This PR adds support for API Keys to the Go SDK.

It updates the middleware to support both access token formatted and api token formatted credentials and performs their associated authentication on matches.

A new `credentials.go` file was added to support format checks.

Also `context.go` is updated to handle the dual locations for these values based on the credential type.

## Access token request to example app

<img width="1655" alt="Screenshot 2025-05-23 at 11 30 50 AM" src="https://github.com/user-attachments/assets/b07e557c-04d2-4243-b948-ec30de4ea059" />


## API key request to example app

```
curl -X POST "http://localhost:8080/" -H "Authorization: Bearer auther_sk_..."
{"credentials":"auther_sk_...","organization_id":"org_cfg0uhl8535r3lx1vs7srocw3"}
```