### PR TITLE
Align JSON casing for config endpoint

### DIFF
--- a/accesstoken/authenticator.go
+++ b/accesstoken/authenticator.go
@@ -260,7 +260,7 @@ func (a *Authenticator) fetchConfig(ctx context.Context) (*configData, error) {
 
 func parseConfig(b []byte) (*configData, error) {
 	var configResponse struct {
-		ProjectID string `json:"projectID"`
+		ProjectID string `json:"projectId"`
 		Keys      []jwk  `json:"keys"`
 	}
 	if err := json.Unmarshal(b, &configResponse); err != nil {


### PR DESCRIPTION
Not a bug, since Go JSON tags are case-insensitive, but aligning this with what's returned from the server for clarity.